### PR TITLE
Fix typo - from 'scope' to 'source'.

### DIFF
--- a/scope-closures/ch2.md
+++ b/scope-closures/ch2.md
@@ -226,7 +226,7 @@ One of the most important aspects of lexical scope is that any time an identifie
 
 ### Lookup Failures
 
-When *Engine* exhausts all *lexically available* scopes and still cannot resolve the lookup of an identifier, an error condition then exists. However, depending on the mode of the program (strict-mode or not) and the role of the variable (i.e., *target* vs. *scope*; see Chapter 1), this error condition will be handled differently.
+When *Engine* exhausts all *lexically available* scopes and still cannot resolve the lookup of an identifier, an error condition then exists. However, depending on the mode of the program (strict-mode or not) and the role of the variable (i.e., *target* vs. *source*; see Chapter 1), this error condition will be handled differently.
 
 If the variable is a *source*, an unresolved identifier lookup is considered an undeclared (unknown, missing) variable, which results in a `ReferenceError` being thrown. Also, if the variable is a *target*, and the code at that point is running in strict-mode, the variable is considered undeclared and throws a `ReferenceError`.
 


### PR DESCRIPTION
Fix typo - from 'scope' to 'source'.

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/You-Dont-Know-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line).

Specifically quoting these guidelines regarding typos:

> Typos?
>
> Please don't worry about minor text typos. These will almost certainly be caught during the editing process.
>
> If you're going to submit a PR for typo fixes, please be measured in doing so by collecting several small changes into a single PR (in separate commits). Or, **just don't even worry about them for now,** because we'll get to them later. I promise.

----

**Please type "I already searched for this issue":**

**Edition:** (pull requests not accepted for previous editions)

**Book Title:**

**Chapter:**

**Section Title:**

**Topic:**
